### PR TITLE
Add notices endpoints (closes #31)

### DIFF
--- a/backend/src/main/java/com/smartentrance/backend/controller/BuildingController.java
+++ b/backend/src/main/java/com/smartentrance/backend/controller/BuildingController.java
@@ -17,7 +17,7 @@ public class BuildingController {
 
     private final BuildingService buildingService;
 
-    @PostMapping("/create")
+    @PostMapping
     public ResponseEntity<BuildingResponse> createBuilding(
             @Valid @RequestBody CreateBuildingRequest request,
             @AuthenticationPrincipal UserPrincipal userPrincipal

--- a/backend/src/main/java/com/smartentrance/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/smartentrance/backend/controller/NoticeController.java
@@ -3,7 +3,7 @@ package com.smartentrance.backend.controller;
 import com.smartentrance.backend.dto.enums.FilterType;
 import com.smartentrance.backend.dto.notice.CreateNoticeRequest;
 import com.smartentrance.backend.dto.notice.NoticeResponse;
-import com.smartentrance.backend.model.Notice;
+import com.smartentrance.backend.dto.notice.UpdateNoticeRequest;
 import com.smartentrance.backend.security.UserPrincipal;
 import com.smartentrance.backend.service.NoticeService;
 import jakarta.validation.Valid;
@@ -16,13 +16,13 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/buildings")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class NoticeController {
 
     private final NoticeService noticeService;
 
-    @PostMapping("/{buildingId}/notices")
+    @PostMapping("/buildings/{buildingId}/notices")
     public ResponseEntity<NoticeResponse> createNotice(
             @PathVariable Integer buildingId,
             @Valid @RequestBody CreateNoticeRequest request,
@@ -32,11 +32,28 @@ public class NoticeController {
         return ResponseEntity.ok(noticeResponse);
     }
 
-    @GetMapping("/{buildingId}/notices")
+    @GetMapping("/buildings/{buildingId}/notices")
     public ResponseEntity<List<NoticeResponse>> getNotices(
             @PathVariable Integer buildingId,
             @RequestParam Optional<FilterType> type
     ) {
         return ResponseEntity.ok(noticeService.getNotices(buildingId, type.orElse(FilterType.ALL)));
+    }
+
+    @DeleteMapping("/notices/{noticeId}")
+    public ResponseEntity<Void> deleteNotice(@PathVariable Integer noticeId,
+                                             @AuthenticationPrincipal UserPrincipal principal) {
+        noticeService.deleteNotice(noticeId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/notices/{noticeId}")
+    public ResponseEntity<NoticeResponse> updateEvent(
+            @PathVariable Integer noticeId,
+            @RequestBody @Valid UpdateNoticeRequest updateData,
+            @AuthenticationPrincipal UserPrincipal principal) {
+
+        return ResponseEntity.ok(noticeService.updateEvent(noticeId, updateData));
     }
 }

--- a/backend/src/main/java/com/smartentrance/backend/controller/PollController.java
+++ b/backend/src/main/java/com/smartentrance/backend/controller/PollController.java
@@ -1,15 +1,13 @@
 package com.smartentrance.backend.controller;
 
 import com.smartentrance.backend.dto.enums.FilterType;
-import com.smartentrance.backend.dto.poll.CastVoteRequest;
-import com.smartentrance.backend.dto.poll.CastVoteResponse;
-import com.smartentrance.backend.dto.poll.CreatePollRequest;
-import com.smartentrance.backend.dto.poll.PollResponse;
+import com.smartentrance.backend.dto.poll.*;
 import com.smartentrance.backend.security.UserPrincipal;
-import com.smartentrance.backend.service.VoteService;
+import com.smartentrance.backend.service.PollService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,39 +15,54 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/buildings")
+@RequestMapping("/api")
 @RequiredArgsConstructor
-public class VoteController {
+public class PollController {
 
-    private final VoteService voteService;
+    private final PollService pollService;
 
-    @GetMapping("/{buildingId}/polls")
+    @GetMapping("/buildings/{buildingId}/polls")
     public ResponseEntity<List<PollResponse>> getPolls(
             @PathVariable Integer buildingId,
             @RequestParam Optional<FilterType> type
     ) {
-        return ResponseEntity.ok(voteService.getPolls(buildingId, type.orElse(FilterType.ALL)));
+        return ResponseEntity.ok(pollService.getPolls(buildingId, type.orElse(FilterType.ALL)));
     }
 
-    @PostMapping("/{buildingId}/polls")
+    @PostMapping("/buildings/{buildingId}/polls")
     public ResponseEntity<PollResponse> createPoll(
             @PathVariable Integer buildingId,
             @Valid @RequestBody CreatePollRequest request,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        PollResponse pollResponse = voteService.createPoll(buildingId, request, userPrincipal.user());
+        PollResponse pollResponse = pollService.createPoll(buildingId, request, userPrincipal.user());
         return ResponseEntity.ok(pollResponse);
     }
 
-    @PostMapping("/{buildingId}/polls/{pollId}/vote")
+    @PostMapping("/polls/{pollId}/vote")
     public ResponseEntity<CastVoteResponse> castVote(
-            @PathVariable Integer buildingId,
             @PathVariable Integer pollId,
             @Valid @RequestBody CastVoteRequest request,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
         return ResponseEntity.ok(
-                voteService.castVote(buildingId, pollId, request, userPrincipal.user())
+                pollService.castVote(pollId, request, userPrincipal.user())
         );
+    }
+
+    @DeleteMapping("/polls/{pollId}")
+    public ResponseEntity<Void> deletePoll(
+            @PathVariable Integer pollId
+    ) {
+        pollService.deletePoll(pollId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/polls/{pollId}")
+    public ResponseEntity<PollResponse> updatePoll(
+            @PathVariable Integer pollId,
+            @Valid @RequestBody UpdatePollRequest request
+    ) {
+        return ResponseEntity.ok(pollService.updatePoll(pollId, request));
     }
 }

--- a/backend/src/main/java/com/smartentrance/backend/dto/enums/PollStatus.java
+++ b/backend/src/main/java/com/smartentrance/backend/dto/enums/PollStatus.java
@@ -4,5 +4,4 @@ public enum PollStatus {
     PLANNED,
     ACTIVE,
     COMPLETED,
-    STOPPED
 }

--- a/backend/src/main/java/com/smartentrance/backend/dto/notice/NoticeResponse.java
+++ b/backend/src/main/java/com/smartentrance/backend/dto/notice/NoticeResponse.java
@@ -1,12 +1,12 @@
-package com.smartentrance.backend.dto.notice;
+    package com.smartentrance.backend.dto.notice;
 
-import java.time.LocalDateTime;
+    import java.time.LocalDateTime;
 
-public record NoticeResponse(
-        Integer id,
-        Integer createdByUserId,
-        String title,
-        String description,
-        String location,
-        LocalDateTime noticeDateTime
-) {}
+    public record NoticeResponse(
+            Integer id,
+            Integer createdByUserId,
+            String title,
+            String description,
+            String location,
+            LocalDateTime noticeDateTime
+    ) {}

--- a/backend/src/main/java/com/smartentrance/backend/dto/notice/UpdateNoticeRequest.java
+++ b/backend/src/main/java/com/smartentrance/backend/dto/notice/UpdateNoticeRequest.java
@@ -1,0 +1,15 @@
+package com.smartentrance.backend.dto.notice;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import java.time.LocalDateTime;
+
+public record UpdateNoticeRequest(
+        String title,
+
+        String description,
+
+        String location,
+
+        @FutureOrPresent(message = "The notice date and time must be in the future or present")
+        LocalDateTime noticeDateTime
+) {}

--- a/backend/src/main/java/com/smartentrance/backend/dto/poll/PollResponse.java
+++ b/backend/src/main/java/com/smartentrance/backend/dto/poll/PollResponse.java
@@ -12,7 +12,6 @@ public record PollResponse(
         String description,
         LocalDateTime startAt,
         LocalDateTime endAt,
-        boolean isActive,
         PollStatus status,
         List<PollOptionResponse> options
 ) {

--- a/backend/src/main/java/com/smartentrance/backend/dto/poll/UpdatePollRequest.java
+++ b/backend/src/main/java/com/smartentrance/backend/dto/poll/UpdatePollRequest.java
@@ -1,0 +1,19 @@
+package com.smartentrance.backend.dto.poll;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record UpdatePollRequest(
+
+        String title,
+
+        String description,
+
+        @FutureOrPresent(message = "Start time should be in the present or future")
+        LocalDateTime startAt,
+
+        @Future(message = "End time should be in the future")
+        LocalDateTime endAt
+) {}

--- a/backend/src/main/java/com/smartentrance/backend/dto/user/RegisterUserRequest.java
+++ b/backend/src/main/java/com/smartentrance/backend/dto/user/RegisterUserRequest.java
@@ -15,9 +15,6 @@ public class RegisterUserRequest {
     private String email;
 
     @NotBlank
-    // @Size(min = 8, message = "Password must be at least 8 characters long")
-    // @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).{8,}$", message = "Password must contain uppercase, lowercase and number")
-    // Uncomment the above annotations to enforce password complexity rules
     private String password;
 
     private boolean rememberMe;

--- a/backend/src/main/java/com/smartentrance/backend/mapper/PollMapper.java
+++ b/backend/src/main/java/com/smartentrance/backend/mapper/PollMapper.java
@@ -16,9 +16,7 @@ public class PollMapper {
 
         PollStatus status;
 
-        if (!poll.isActive()) {
-            status = PollStatus.STOPPED;
-        } else if (now.isBefore(poll.getStartAt())) {
+        if (now.isBefore(poll.getStartAt())) {
             status = PollStatus.PLANNED;
         } else if (now.isAfter(poll.getEndAt())) {
             status = PollStatus.COMPLETED;
@@ -37,7 +35,6 @@ public class PollMapper {
                 poll.getDescription(),
                 poll.getStartAt(),
                 poll.getEndAt(),
-                poll.isActive(),
                 status,
                 options
         );

--- a/backend/src/main/java/com/smartentrance/backend/model/VotesPoll.java
+++ b/backend/src/main/java/com/smartentrance/backend/model/VotesPoll.java
@@ -53,8 +53,10 @@ public class VotesPoll {
     @ToString.Exclude
     private List<VotesOption> options = new ArrayList<>();
 
-    @Column(name = "is_active", nullable = false)
-    private boolean isActive = true;
+    @OneToMany(mappedBy = "poll", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
+    @ToString.Exclude
+    private List<UserVote> votes = new ArrayList<>();
 
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/smartentrance/backend/repository/VotesPollRepository.java
+++ b/backend/src/main/java/com/smartentrance/backend/repository/VotesPollRepository.java
@@ -16,7 +16,6 @@ public interface VotesPollRepository extends JpaRepository<VotesPoll, Integer> {
     @Query("""
         SELECT p FROM VotesPoll p 
         WHERE p.building.id = :buildingId 
-        AND p.isActive = true 
         AND :now BETWEEN p.startAt AND p.endAt
         ORDER BY p.endAt ASC
     """)
@@ -25,7 +24,7 @@ public interface VotesPollRepository extends JpaRepository<VotesPoll, Integer> {
     @Query("""
         SELECT p FROM VotesPoll p 
         WHERE p.building.id = :buildingId 
-        AND (p.isActive = false OR p.endAt < :now)
+        AND p.endAt < :now
         ORDER BY p.endAt DESC
     """)
     List<VotesPoll> findAllHistory(@Param("buildingId") Integer buildingId, @Param("now") LocalDateTime now);

--- a/backend/src/main/java/com/smartentrance/backend/security/BuildingSecurity.java
+++ b/backend/src/main/java/com/smartentrance/backend/security/BuildingSecurity.java
@@ -1,7 +1,10 @@
 package com.smartentrance.backend.security;
 
+import com.smartentrance.backend.model.Building;
 import com.smartentrance.backend.repository.BuildingRepository;
+import com.smartentrance.backend.repository.NoticeRepository;
 import com.smartentrance.backend.repository.UnitRepository;
+import com.smartentrance.backend.repository.VotesPollRepository;
 import lombok.RequiredArgsConstructor;
  import org.springframework.stereotype.Component;
 
@@ -11,6 +14,8 @@ public class BuildingSecurity {
 
     private final BuildingRepository buildingRepository;
     private final UnitRepository unitRepository;
+    private final NoticeRepository noticeRepository;
+    private final VotesPollRepository pollRepository;
 
     public boolean hasAccess(Integer buildingId, Integer userId) {
         return buildingRepository.existsByIdAndManagerId(buildingId, userId)
@@ -20,5 +25,37 @@ public class BuildingSecurity {
 
     public boolean isManager(Integer buildingId, Integer userId) {
         return buildingRepository.existsByIdAndManagerId(buildingId, userId);
+    }
+
+    public boolean canManageNotice(Integer noticeId, Integer userId) {
+        // 1. Търсим съобщението
+        return noticeRepository.findById(noticeId)
+                .map(notice -> {
+                    Building building = notice.getBuilding();
+
+                    return building.getManager().getId().equals(userId);
+                })
+                .orElse(false);
+    }
+
+    public boolean canVote(Integer pollId, Integer unitId, Integer userId) {
+        return pollRepository.findById(pollId)
+                .map(poll -> unitRepository.findById(unitId)
+                        .map(unit -> {
+                            boolean isResponsible = unit.getResponsibleUser() != null
+                                    && unit.getResponsibleUser().getId().equals(userId);
+
+                            boolean sameBuilding = unit.getBuilding().getId().equals(poll.getBuilding().getId());
+
+                            return isResponsible && sameBuilding;
+                        })
+                        .orElse(false))
+                .orElse(false);
+    }
+
+    public boolean canManagePoll(Integer pollId, Integer userId) {
+        return pollRepository.findById(pollId)
+                .map(poll -> poll.getBuilding().getManager().getId().equals(userId))
+                .orElse(false);
     }
 }

--- a/backend/src/main/java/com/smartentrance/backend/service/UnitService.java
+++ b/backend/src/main/java/com/smartentrance/backend/service/UnitService.java
@@ -62,9 +62,10 @@ public class UnitService {
         unitRepository.saveAll(units);
     }
 
-    public Optional<Unit> findByIdAndResponsibleUser(Integer unitId, User user) {
-        return unitRepository.findByIdAndResponsibleUser(unitId, user);
+    public Optional<Unit> findById(Integer id) {
+        return unitRepository.findById(id);
     }
+
     public List<Unit> findAllByResponsibleUserId(Integer userId) {
         return unitRepository.findAllByResponsibleUserId(userId);
     }


### PR DESCRIPTION
Refactored API endpoints for cleaner URLs and added security checks to prevent unauthorized editing or deleting. Updated logic to protect past notices and active polls from modification, and removed redundant status columns from the database to rely on server time.