### PR TITLE
Disable Stripe components via payment.stripe.enabled property

### DIFF
--- a/backend/src/main/java/com/smartentrance/backend/payment/StripeConfig.java
+++ b/backend/src/main/java/com/smartentrance/backend/payment/StripeConfig.java
@@ -3,9 +3,15 @@ package com.smartentrance.backend.payment;
 import com.stripe.Stripe;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConditionalOnProperty(
+        name = "payment.stripe.enabled",  // property that controls loading
+        havingValue = "true",
+        matchIfMissing = false            // if property is missing, bean won't load
+)
 @RequiredArgsConstructor
 public class StripeConfig {
 

--- a/backend/src/main/java/com/smartentrance/backend/payment/StripeProperties.java
+++ b/backend/src/main/java/com/smartentrance/backend/payment/StripeProperties.java
@@ -1,11 +1,12 @@
 package com.smartentrance.backend.payment;
 
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+@ConditionalOnProperty(name = "payment.stripe.enabled", havingValue = "true")
 @ConfigurationProperties(prefix = "stripe")
-@Validated
 public record StripeProperties(
         @NotBlank(message = "Stripe API Key must not be empty")
         String apiKey,

--- a/backend/src/main/java/com/smartentrance/backend/payment/StripeWebhookController.java
+++ b/backend/src/main/java/com/smartentrance/backend/payment/StripeWebhookController.java
@@ -10,6 +10,7 @@ import com.stripe.net.Webhook;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,6 +18,11 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 @RestController
+@ConditionalOnProperty(
+        name = "payment.stripe.enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
 @RequestMapping("/api/webhooks")
 @RequiredArgsConstructor
 public class StripeWebhookController {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -38,8 +38,9 @@ payment:
   currency: EUR
 
   stripe:
-    api-key: ${STRIPE_API_KEY}
-    webhook-secret: ${STRIPE_WEBHOOK_SECRET}
+    enabled: false
+    # api-key: ${STRIPE_API_KEY}
+    # webhook-secret: ${STRIPE_WEBHOOK_SECRET}
 
 file:
     upload-dir: ./backend/uploads


### PR DESCRIPTION
Added @ConditionalOnProperty annotations to StripeConfig, StripeProperties, and StripeWebhookController to ensure these beans are only loaded when 'payment.stripe.enabled' is set to true. This allows conditional activation of Stripe payment integration based on application configuration.